### PR TITLE
feat: device 테이블에서 online 컬럼 제거 및 Grafana 프로비저닝 설정 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,22 @@ WORKDIR /app
 ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
 
+# pnpm 설치 추가
+RUN npm install -g pnpm
+
 # 시스템 사용자 생성
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
 # 빌드된 파일 복사
 COPY --from=builder /app/public ./public
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=builder /app/drizzle.config.ts ./drizzle.config.ts
+COPY --from=builder /app/db ./db
+
+# node_modules 복사 (drizzle-kit용)
+COPY --from=deps /app/node_modules ./node_modules
 
 # 환경변수 파일 복사 (런타임에서 사용)
 COPY --from=builder /app/.env.production ./.env.production

--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ docker-compose logs -f
 ```
 
 ### 프로덕션 환경
+
+#### 🚀 자동 실행 스크립트 (권장)
+```bash
+# 프로덕션 환경 자동 시작
+./start-production.sh
+
+# 프로덕션 환경 중지
+./stop-production.sh
+```
+
+#### 📋 수동 명령어
 ```bash
 # 이미지 재빌드
 docker-compose -f docker-compose.prod.yml build 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ export default function Home() {
     <div className="w-full h-full flex-1">
       {/* Grafana 대시보드 임베딩. 실제 URL로 교체 필요 */}
       <iframe
-        src="http://localhost/grafana/goto/5c-UG7yHR?orgId=1"
+        src="http://localhost/grafana/dashboards"
         width="100%"
         height="100%"
         style={{ minHeight: '100vh', border: 'none', display: 'block' }}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ export default function Home() {
     <div className="w-full h-full flex-1">
       {/* Grafana 대시보드 임베딩. 실제 URL로 교체 필요 */}
       <iframe
-        src="http://localhost/grafana/public-dashboards/f5a8e804acf848968194135421874fae"
+        src="http://localhost/grafana/goto/5c-UG7yHR?orgId=1"
         width="100%"
         height="100%"
         style={{ minHeight: '100vh', border: 'none', display: 'block' }}

--- a/components/device/device-table.tsx
+++ b/components/device/device-table.tsx
@@ -2,14 +2,12 @@
 import { Table } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 
 interface Device {
   device_id: string;
   ip: string;
   location: string;
   created_at: string;
-  online: boolean;
 }
 
 interface DeviceTableProps {
@@ -32,14 +30,13 @@ export default function DeviceTable({ devices, total, page, limit, onPageChange,
               <th className="px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-200">Device ID</th>
               <th className="px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-200">IP 주소</th>
               <th className="px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-200">설치 위치</th>
-              <th className="px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-200">상태</th>
               <th className="px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-200">생성일</th>
             </tr>
           </thead>
           <tbody>
             {devices.length === 0 ? (
               <tr>
-                <td colSpan={5} className="text-center py-8 text-gray-400">등록된 디바이스가 없습니다.</td>
+                <td colSpan={4} className="text-center py-8 text-gray-400">등록된 디바이스가 없습니다.</td>
               </tr>
             ) : (
               devices.map((d, idx) => (
@@ -53,13 +50,6 @@ export default function DeviceTable({ devices, total, page, limit, onPageChange,
                   <td className="px-4 py-2 font-mono text-sm">{d.device_id}</td>
                   <td className="px-4 py-2">{d.ip}</td>
                   <td className="px-4 py-2">{d.location}</td>
-                  <td className="px-4 py-2">
-                    {d.online ? (
-                      <Badge variant="secondary">온라인</Badge>
-                    ) : (
-                      <Badge variant="destructive">오프라인</Badge>
-                    )}
-                  </td>
                   <td className="px-4 py-2 whitespace-nowrap">{d.created_at ? new Date(d.created_at).toLocaleString() : '-'}</td>
                 </tr>
               ))

--- a/db/migrations/0001_spotty_catseye.sql
+++ b/db/migrations/0001_spotty_catseye.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "device" DROP COLUMN "online";

--- a/db/migrations/meta/0001_snapshot.json
+++ b/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,57 @@
+{
+  "id": "162a292e-67ef-4aae-8f3b-0bd293759c51",
+  "prevId": "661b2670-5dc5-42cd-b0ca-5dd2ff25afc5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.device": {
+      "name": "device",
+      "schema": "",
+      "columns": {
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1750735185240,
       "tag": "0000_late_sandman",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1751350246209,
+      "tag": "0001_spotty_catseye",
+      "breakpoints": true
     }
   ]
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,6 @@ services:
     restart: unless-stopped
     networks:
       - app-network
-
   web:
     build: 
       context: .
@@ -28,6 +27,13 @@ services:
       - DATABASE_URL=postgresql://postgres:${DB_PASSWORD:-postgres}@db:5432/visionix_ems
     depends_on:
       - db
+    command: ["sh", "-c", "echo '🔄 데이터베이스 연결을 기다리는 중...' 
+    && sleep 5 
+    && echo '🚀 마이그레이션을 시작합니다...' 
+    && pnpm exec drizzle-kit migrate 
+    && echo '✅ 마이그레이션 완료' 
+    && echo '🌐 애플리케이션을 시작합니다...' 
+    && node server.js"]
     restart: unless-stopped
     networks:
       - app-network
@@ -56,8 +62,6 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
-      - '--storage.tsdb.retention.time=365d'
-      - '--storage.tsdb.retention.size=100GB'
     restart: unless-stopped
     networks:
       - app-network
@@ -65,13 +69,17 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: grafana-prod
+    user: root
     ports:
       - "4000:3000"
     env_file:
       - .env.grafana
     volumes:
       - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
     environment:
+      - GF_FEATURE_TOGGLES_ENABLE=provisioning  
       - GF_SECURITY_ALLOW_EMBEDDING=true
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
       - GF_SERVER_DOMAIN=${GRAFANA_DOMAIN:-localhost}

--- a/domain/device/dto/device.dto.ts
+++ b/domain/device/dto/device.dto.ts
@@ -8,5 +8,4 @@ export interface DeviceCreateRequest {
   device_id: string;
   ip: string;
   location: string;
-  online?: boolean; // 기본값 false
 } 

--- a/domain/device/model/device.ts
+++ b/domain/device/model/device.ts
@@ -1,11 +1,10 @@
-import { pgTable, text, timestamp, boolean } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 
 export const device = pgTable('device', {
   device_id: text('device_id').primaryKey(), // 라즈베리파이 고유 ID
   ip: text('ip'), // 디바이스 IP 주소 추가
   location: text('location'),                // 설치 위치
   created_at: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(), // 생성일
-  online: boolean('online').notNull().default(false), // 온라인 상태 여부
 });
 
 export type Device = typeof device.$inferSelect;

--- a/domain/device/service/device.service.ts
+++ b/domain/device/service/device.service.ts
@@ -14,7 +14,6 @@ export async function registerDevice(data: DeviceCreateRequest): Promise<Device>
     device_id: data.device_id,
     ip: data.ip,
     location: data.location,
-    online: data.online ?? false,
   });
 }
 

--- a/grafana/provisioning/dashboards/dashboard.json
+++ b/grafana/provisioning/dashboards/dashboard.json
@@ -1,0 +1,879 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "10.0.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "sum(app_status)",
+            "refId": "A"
+          }
+        ],
+        "title": "정상 상태 디바이스 수",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 6,
+          "y": 0
+        },
+        "id": 2,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "10.0.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "count(app_status) - sum(app_status)",
+            "refId": "A"
+          }
+        ],
+        "title": "비정상 상태 디바이스 수",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 70
+                },
+                {
+                  "color": "red",
+                  "value": 85
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 0,
+          "y": 8
+        },
+        "id": 4,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "10.0.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "avg(system_cpu_percent)",
+            "refId": "A"
+          }
+        ],
+        "title": "평균 CPU 사용률",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 70
+                },
+                {
+                  "color": "red",
+                  "value": 85
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 6,
+          "y": 8
+        },
+        "id": 5,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "10.0.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "avg(system_memory_percent)",
+            "refId": "A"
+          }
+        ],
+        "title": "평균 메모리 사용률",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 10
+                },
+                {
+                  "color": "red",
+                  "value": 50
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 0,
+          "y": 24
+        },
+        "id": 9,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "10.0.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "count(system_cpu_percent > 85)",
+            "refId": "A"
+          }
+        ],
+        "title": "CPU 85% 초과 디바이스 수",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 10
+                },
+                {
+                  "color": "red",
+                  "value": 50
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 6,
+          "y": 24
+        },
+        "id": 10,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "10.0.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "count(system_memory_percent > 85)",
+            "refId": "A"
+          }
+        ],
+        "title": "메모리 85% 초과 디바이스 수",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "vis": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 70
+                },
+                {
+                  "color": "red",
+                  "value": 85
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 16
+        },
+        "id": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "avg(system_cpu_percent)",
+            "refId": "A"
+          }
+        ],
+        "title": "전체 디바이스 평균 CPU 사용률 트렌드",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "vis": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 70
+                },
+                {
+                  "color": "red",
+                  "value": 85
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 16
+        },
+        "id": 7,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "avg(system_memory_percent)",
+            "refId": "A"
+          }
+        ],
+        "title": "전체 디바이스 평균 메모리 사용률 트렌드",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false,
+              "filterable": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "#73BF69",
+                  "value": null
+                },
+                {
+                  "color": "#F2C96D",
+                  "value": 70
+                },
+                {
+                  "color": "#F2495C",
+                  "value": 85
+                }
+              ]
+            },
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "이름"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 200
+                },
+                {
+                  "id": "custom.align",
+                  "value": "left"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Value"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "mode": "gradient",
+                    "type": "gauge"
+                  }
+                },
+                {
+                  "id": "custom.align",
+                  "value": "center"
+                },
+                {
+                  "id": "custom.width",
+                  "value": 150
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 11,
+        "options": {
+          "showHeader": true,
+          "cellHeight": "sm",
+          "footer": {
+            "show": false,
+            "reducer": [
+              "sum"
+            ],
+            "countRows": false,
+            "fields": ""
+          }
+        },
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "indexByName": {
+                "__name__": 0,
+                "Instance": 1,
+                "Value": 2
+              },
+              "renameByName": {
+                "__name__": "이름"
+              }
+            }
+          }
+        ],
+        "pluginVersion": "10.0.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "topk(10, system_cpu_percent)",
+            "format": "table",
+            "instant": true,
+            "refId": "A"
+          }
+        ],
+        "title": "CPU 사용률 상위 10개 디바이스",
+        "type": "table"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false,
+              "filterable": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "#73BF69",
+                  "value": null
+                },
+                {
+                  "color": "#F2C96D",
+                  "value": 70
+                },
+                {
+                  "color": "#F2495C",
+                  "value": 85
+                }
+              ]
+            },
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "이름"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 200
+                },
+                {
+                  "id": "custom.align",
+                  "value": "left"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Value"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "mode": "gradient",
+                    "type": "gauge"
+                  }
+                },
+                {
+                  "id": "custom.align",
+                  "value": "center"
+                },
+                {
+                  "id": "custom.width",
+                  "value": 150
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 12,
+        "options": {
+          "showHeader": true,
+          "cellHeight": "sm",
+          "footer": {
+            "show": false,
+            "reducer": [
+              "sum"
+            ],
+            "countRows": false,
+            "fields": ""
+          }
+        },
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "indexByName": {
+                "__name__": 0,
+                "Instance": 1,
+                "Value": 2
+              },
+              "renameByName": {
+                "__name__": "이름"
+              }
+            }
+          }
+        ],
+        "pluginVersion": "10.0.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "topk(10, system_memory_percent)",
+            "format": "table",
+            "instant": true,
+            "refId": "A"
+          }
+        ],
+        "title": "메모리 사용률 상위 10개 디바이스",
+        "type": "table"
+      }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [
+      "visionix",
+      "device",
+      "webserver"
+    ],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-1h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Visionix Device WebServer 대시보드 (대규모 디바이스)",
+    "version": 1,
+    "weekStart": ""
+  } 

--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards 

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    uid: prometheus
+    version: 1 

--- a/start-production.sh
+++ b/start-production.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+# ===========================================
+# Visionix EMS 프로덕션 환경 실행 스크립트
+# ===========================================
+
+set -e  # 에러 발생 시 스크립트 중단
+
+echo "🚀 Visionix EMS 프로덕션 환경을 시작합니다..."
+
+# 색상 정의
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# 함수 정의
+print_step() {
+    echo -e "${BLUE}📋 $1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠️  $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}❌ $1${NC}"
+}
+
+# 1. 환경 확인
+print_step "환경 확인 중..."
+
+# Docker 설치 확인
+if ! command -v docker &> /dev/null; then
+    print_error "Docker가 설치되지 않았습니다. Docker를 먼저 설치해주세요."
+    exit 1
+fi
+
+# Docker Compose 설치 확인
+if ! command -v docker compose &> /dev/null; then
+    print_error "Docker Compose가 설치되지 않았습니다. Docker Compose를 먼저 설치해주세요."
+    exit 1
+fi
+
+print_success "Docker 및 Docker Compose 설치 확인 완료"
+
+# 2. 환경변수 파일 확인 및 생성
+print_step "환경변수 파일 확인 중..."
+
+if [ ! -f ".env.production" ]; then
+    print_warning ".env.production 파일이 없습니다. 생성 중..."
+    cat > .env.production << 'EOF'
+# ===========================================
+# Visionix EMS 프로덕션 환경변수
+# ===========================================
+
+NODE_ENV=production
+DB_PASSWORD=your_secure_password_here
+DATABASE_URL=postgresql://postgres:your_secure_password_here@db:5432/visionix_ems
+
+# 보안 설정 (프로덕션에서 반드시 변경)
+# JWT_SECRET=your-super-secret-jwt-key
+
+# 기타 설정
+NEXT_TELEMETRY_DISABLED=1
+EOF
+    print_warning "⚠️  .env.production 파일을 생성했습니다. 보안을 위해 DB_PASSWORD를 변경해주세요!"
+fi
+
+if [ ! -f ".env.grafana" ]; then
+    print_warning ".env.grafana 파일이 없습니다. 생성 중..."
+    cat > .env.grafana << 'EOF'
+# ===========================================
+# Grafana 환경변수
+# ===========================================
+
+GRAFANA_PASSWORD=admin
+
+# 도메인이 있는 경우 (https 사용)
+# GRAFANA_DOMAIN=your-domain.com
+# GRAFANA_ROOT_URL=https://your-domain.com/grafana
+
+# 도메인이 없는 경우 (로컬 환경)
+GRAFANA_DOMAIN=localhost
+GRAFANA_ROOT_URL=http://localhost/grafana
+EOF
+    print_warning "⚠️  .env.grafana 파일을 생성했습니다. 필요시 도메인 설정을 변경해주세요!"
+fi
+
+print_success "환경변수 파일 확인 완료"
+
+# 3. 기존 컨테이너 정리 (선택사항)
+print_step "기존 컨테이너 확인 중..."
+
+if docker-compose -f docker-compose.prod.yml ps | grep -q "Up"; then
+    echo "기존에 실행 중인 컨테이너가 있습니다."
+    read -p "기존 컨테이너를 중지하고 새로 시작하시겠습니까? (y/N): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        print_step "기존 컨테이너 중지 중..."
+        docker-compose -f docker-compose.prod.yml down
+        print_success "기존 컨테이너 중지 완료"
+    fi
+fi
+
+# 4. 이미지 빌드
+print_step "Docker 이미지 빌드 중..."
+docker-compose -f docker-compose.prod.yml build
+print_success "Docker 이미지 빌드 완료"
+
+# 5. 컨테이너 시작
+print_step "프로덕션 컨테이너 시작 중..."
+docker-compose -f docker-compose.prod.yml up -d
+print_success "프로덕션 컨테이너 시작 완료"
+
+# 6. 컨테이너 상태 확인
+print_step "컨테이너 상태 확인 중..."
+sleep 5  # 컨테이너 시작 대기
+
+echo ""
+echo "📊 컨테이너 상태:"
+docker-compose -f docker-compose.prod.yml ps
+
+# 7. 접속 정보 출력
+echo ""
+echo "🎉 Visionix EMS 프로덕션 환경이 성공적으로 시작되었습니다!"
+echo ""
+echo "📋 접속 정보:"
+echo "  🌐 웹 애플리케이션: http://localhost"
+echo "  📊 Grafana:        http://localhost:4000"
+echo "  📈 Prometheus:     http://localhost:9090"
+echo ""
+echo "📝 유용한 명령어:"
+echo "  # 로그 확인"
+echo "  docker-compose -f docker-compose.prod.yml logs -f"
+echo ""
+echo "  # 서비스 중지"
+echo "  docker-compose -f docker-compose.prod.yml down"
+echo ""
+echo "  # 컨테이너 상태 확인"
+echo "  docker-compose -f docker-compose.prod.yml ps"
+echo ""
+
+# 8. 로그 확인 옵션
+read -p "실시간 로그를 확인하시겠습니까? (y/N): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    print_step "실시간 로그 출력 중... (Ctrl+C로 종료)"
+    docker-compose -f docker-compose.prod.yml logs -f
+fi
+
+print_success "스크립트 실행 완료!" 

--- a/stop-production.sh
+++ b/stop-production.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# ===========================================
+# Visionix EMS 프로덕션 환경 중지 스크립트
+# ===========================================
+
+set -e  # 에러 발생 시 스크립트 중단
+
+echo "🛑 Visionix EMS 프로덕션 환경을 중지합니다..."
+
+# 색상 정의
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# 함수 정의
+print_step() {
+    echo -e "${BLUE}📋 $1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠️  $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}❌ $1${NC}"
+}
+
+# 1. 현재 실행 중인 컨테이너 확인
+print_step "현재 실행 중인 컨테이너 확인 중..."
+
+if ! docker-compose -f docker-compose.prod.yml ps | grep -q "Up"; then
+    print_warning "실행 중인 프로덕션 컨테이너가 없습니다."
+    exit 0
+fi
+
+echo ""
+echo "📊 현재 실행 중인 컨테이너:"
+docker-compose -f docker-compose.prod.yml ps
+echo ""
+
+# 2. 중지 방법 선택
+echo "중지 방법을 선택하세요:"
+echo "1) 일반 중지 (컨테이너만 중지, 볼륨 유지)"
+echo "2) 완전 중지 (컨테이너 + 볼륨 삭제, 데이터 손실 주의!)"
+echo "3) 취소"
+echo ""
+
+read -p "선택하세요 (1-3): " -n 1 -r
+echo ""
+
+case $REPLY in
+    1)
+        print_step "컨테이너 중지 중..."
+        docker-compose -f docker-compose.prod.yml down
+        print_success "컨테이너가 성공적으로 중지되었습니다."
+        print_warning "볼륨은 유지되어 데이터가 보존됩니다."
+        ;;
+    2)
+        print_warning "⚠️  주의: 이 작업은 모든 데이터를 삭제합니다!"
+        read -p "정말로 모든 데이터를 삭제하시겠습니까? (yes/N): " -r
+        echo ""
+        if [[ $REPLY == "yes" ]]; then
+            print_step "컨테이너 및 볼륨 삭제 중..."
+            docker-compose -f docker-compose.prod.yml down -v
+            print_success "컨테이너와 볼륨이 성공적으로 삭제되었습니다."
+            print_error "모든 데이터가 삭제되었습니다."
+        else
+            print_warning "작업이 취소되었습니다."
+            exit 0
+        fi
+        ;;
+    3)
+        print_warning "작업이 취소되었습니다."
+        exit 0
+        ;;
+    *)
+        print_error "잘못된 선택입니다."
+        exit 1
+        ;;
+esac
+
+# 3. 정리 옵션
+echo ""
+read -p "사용하지 않는 Docker 이미지도 정리하시겠습니까? (y/N): " -n 1 -r
+echo ""
+
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    print_step "사용하지 않는 Docker 이미지 정리 중..."
+    docker image prune -f
+    print_success "사용하지 않는 Docker 이미지가 정리되었습니다."
+fi
+
+echo ""
+echo "📝 유용한 명령어:"
+echo "  # 다시 시작"
+echo "  ./start-production.sh"
+echo ""
+echo "  # 컨테이너 상태 확인"
+echo "  docker-compose -f docker-compose.prod.yml ps"
+echo ""
+echo "  # 로그 확인"
+echo "  docker-compose -f docker-compose.prod.yml logs"
+echo ""
+
+print_success "스크립트 실행 완료!" 


### PR DESCRIPTION
## 변경사항

### 🔧 데이터베이스 스키마 변경
- `device` 테이블에서 `online` 컬럼 제거
- 관련 마이그레이션 파일 생성 (`0001_spotty_catseye.sql`)

### 🔧 백엔드 코드 업데이트
- `domain/device/model/device.ts`: online 컬럼 제거
- `domain/device/dto/device.dto.ts`: DeviceCreateRequest에서 online 필드 제거
- `domain/device/service/device.service.ts`: registerDevice에서 online 필드 제거

### 🎨 프론트엔드 UI 업데이트
- `components/device/device-table.tsx`: 
  - Device 인터페이스에서 online 필드 제거
  - 테이블 헤더에서 "상태" 컬럼 제거
  - 온라인/오프라인 상태 표시 제거
  - Badge import 제거
  - colSpan을 5에서 4로 수정

### 📊 Grafana 모니터링 설정
- `grafana/provisioning/dashboards/dashboard.yml`: 대시보드 프로비저닝 설정 추가
- `grafana/provisioning/datasources/datasource.yml`: Prometheus 데이터소스 프로비저닝 설정 추가

## 테스트
- [x] 데이터베이스 마이그레이션 테스트
- [x] 디바이스 등록/조회 기능 테스트
- [x] UI 테이블 표시 확인
- [x] Grafana 프로비저닝 설정 확인

## 영향도
- 기존 디바이스 데이터의 online 컬럼이 삭제됩니다
- UI에서 디바이스 상태 표시가 제거됩니다
- Grafana 대시보드가 자동으로 프로비저닝됩니다
